### PR TITLE
継続的共有／一時的共有のレスポンスが配列にならない場合がある問題の修正 issue/#98

### DIFF
--- a/delivery/manifest/eks/configmap/application000001/access-control-service-container.yaml
+++ b/delivery/manifest/eks/configmap/application000001/access-control-service-container.yaml
@@ -49,6 +49,9 @@ data:
       session: http://localhost:3000/operator/session
 
     timezone: Asia/Tokyo
+
+    # APIトークン有効期限チェック時に使用するバッファ時間（秒）
+    bufferTime: 10
   log4js.config.json: |
     {
       "appenders": {

--- a/delivery/manifest/eks/configmap/region000001/access-control-service-container.yaml
+++ b/delivery/manifest/eks/configmap/region000001/access-control-service-container.yaml
@@ -49,6 +49,9 @@ data:
       session: http://localhost:3000/operator/session
 
     timezone: Asia/Tokyo
+
+    # APIトークン有効期限チェック時に使用するバッファ時間（秒）
+    bufferTime: 10
   log4js.config.json: |
     {
       "appenders": {

--- a/delivery/manifest/eks/configmap/root/access-control-manage-service-container.yaml
+++ b/delivery/manifest/eks/configmap/root/access-control-manage-service-container.yaml
@@ -60,6 +60,8 @@ data:
       getSharingDataDefinition: http://localhost:3005/book-manage/setting/share/
       collationTemporaryShareCode: http://localhost:3005/book-manage/share/temp/collation
       getBookInd: http://localhost:3005/book-manage/
+      postStorePermission: http://localhost:3005/book-manage/settings/store/permission
+      postSharePermission: http://localhost:3005/book-manage/setting/share/permission
 
     accessControlService:
       local:

--- a/delivery/manifest/eks/configmap/root/access-control-service-container.yaml
+++ b/delivery/manifest/eks/configmap/root/access-control-service-container.yaml
@@ -49,6 +49,9 @@ data:
       session: http://localhost:3000/operator/session
 
     timezone: Asia/Tokyo
+
+    # APIトークン有効期限チェック時に使用するバッファ時間（秒）
+    bufferTime: 10
   log4js.config.json: |
     {
       "appenders": {


### PR DESCRIPTION
## 修正内容
* access-control-serviceのdefault.ymlに、bufferTime：APIトークン有効期限チェック時に使用するバッファ時間（秒）の設定を追加。
  * ブロックごとにAPIトークン有効期限がズレないようにする
  * 有効期限チェック時にはバッファを設ける（イメージ：有効期限の日時＜Now＋バッファ時間）
    * ※バッファ時間は10s程度が妥当だが、10がマジックナンバーにならないように定義する
* access-control-manage-serviceからbook-manageへのpostStorePermission/postSharePermissionを追加。
  * localhost:3005のポート番号設定は、book-manage側のconfig/default.ymlと、manifestに依存。