### PR TITLE
モノ追加API実行時の文字列制限の解除（book-operate-service）issue/#109

### DIFF
--- a/database/pxr-book-operate-service/book_operator_5377_alter.sql
+++ b/database/pxr-book-operate-service/book_operator_5377_alter.sql
@@ -1,0 +1,2 @@
+-- cmatrix_floating_columnのvalueカラムの型をtextに変更
+ALTER TABLE pxr_book_operate.cmatrix_floating_column ALTER COLUMN value TYPE text;

--- a/database/pxr-book-operate-service/createTable.sql
+++ b/database/pxr-book-operate-service/createTable.sql
@@ -503,7 +503,7 @@ CREATE TABLE IF NOT EXISTS pxr_book_operate.cmatrix_floating_column
     id bigserial,
     cmatrix_thing_id bigint NOT NULL,
     index_key varchar(255) NOT NULL,
-    value varchar(255),
+    value text,
     is_disabled boolean NOT NULL DEFAULT false,
     created_by varchar(255) NOT NULL,
     created_at timestamp(3) NOT NULL DEFAULT NOW(),


### PR DESCRIPTION
issue/#109
「モノ追加API実行時にvalueに設定する文字列が長い場合503エラーとなる」の修正