### PR TITLE
データ出力準備APIの静的認可追加する修正（流通制御SPの運営メンバー） issue/#110

### DIFF
--- a/delivery/manifest/eks/configmap/root/pxr-block-proxy-service-container.yaml
+++ b/delivery/manifest/eks/configmap/root/pxr-block-proxy-service-container.yaml
@@ -1179,6 +1179,7 @@ data:
             "^\\/book-manage\\/user\\/info\\/?$",
             "^\\/book-manage\\/output\\/?\\?.*\\/?$",
             "^\\/book-manage\\/output\\/condition\\/data_mng\\/search\\/?\\?.*\\/?$",
+            "^\\/book-manage\\/output\\/condition\\/prepare\\/?$",
             "^\\/identity-verificate\\/code\\/?$",
             "^\\/identity-verificate\\/code\\/verified\\/?$",
             "^\\/identity-verificate\\/url\\/?$",


### PR DESCRIPTION
issue/#110
「流通制御の運営メンバーでログインしデータ出力準備API実行するとエラーとなる」の修正